### PR TITLE
Read input stream directly into the buffer used for fs2 chunk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import scala.scalanative.build._
 nativeConfig ~= {
   _.withLTO(LTO.full)
   .withMode(Mode.releaseFull)
-  .withGC(GC.immix)
+  .withGC(GC.commix)
 }
 
 vcpkgNativeConfig ~= {
@@ -35,7 +35,7 @@ bindgenBindings := {
 lazy val root = project
   .in(file("."))
   .settings(
-    name := "pedalboard",
+    name := "arpeggio",
     version := "0.1.0-SNAPSHOT",
     scalaVersion := scala3Version,
     libraryDependencies += "org.typelevel" %%% "cats-effect" % "3.5.1",

--- a/src/main/scala/io/input.scala
+++ b/src/main/scala/io/input.scala
@@ -12,18 +12,12 @@ import scala.scalanative.unsigned.UnsignedRichInt
 def inputStreamFromPointer[F[_]](pStream: Ptr[PaStream])(implicit
     F: Sync[F]
 ): Stream[F, Float] =
-  val pFloat: Ptr[Float] = stackalloc[Float](FRAMES_PER_BUFFER)
-  val pByte: Ptr[Byte] = pFloat.toBytePointer
+  val buffer = new Array[Float](FRAMES_PER_BUFFER)
   Pull
     .eval(F.blocking {
-      functions.Pa_ReadStream(pStream, pByte, FRAMES_PER_BUFFER.toULong)
-      arrayChunk(pFloat, FRAMES_PER_BUFFER)
+      functions.Pa_ReadStream(pStream, buffer.atUnsafe(0).toBytePointer, FRAMES_PER_BUFFER.toULong)
+      Chunk.ArraySlice(buffer, 0, FRAMES_PER_BUFFER)
     })
     .flatMap(Pull.output)
     .streamNoScope
     .repeat
-
-private def arrayChunk(pointer: Ptr[Float], length: Int): Chunk[Float] =
-  val array = new Array[Float](length)
-  (0 until length).foreach(i => array(i) = pointer(i))
-  Chunk.array(array)


### PR DESCRIPTION
Learned about the `atUnsafe` method to get a buffer from an array, so no need to explicitly create a pointer and copy the data across. Speeds up performance considerably.