### PR TITLE
Increase maxColumn to 100 in .scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,4 @@
 version = 3.7.14
 runner.dialect = scala3
+
+maxColumn = 100

--- a/src/main/scala/io/portaudio/defaultPaStream.scala
+++ b/src/main/scala/io/portaudio/defaultPaStream.scala
@@ -18,8 +18,7 @@ private def inputStreamParams(using Zone): Ptr[PaStreamParameters] =
     device = inputDevice,
     channelCount = 1,
     sampleFormat = PaSampleFormat.paFloat32,
-    suggestedLatency =
-      (!functions.Pa_GetDeviceInfo(inputDevice)).defaultLowInputLatency,
+    suggestedLatency = (!functions.Pa_GetDeviceInfo(inputDevice)).defaultLowInputLatency,
     hostApiSpecificStreamInfo = null
   )
 
@@ -29,8 +28,7 @@ private def outputStreamParams(using Zone): Ptr[PaStreamParameters] =
     device = functions.Pa_GetDefaultOutputDevice(),
     channelCount = 1,
     sampleFormat = PaSampleFormat.paFloat32,
-    suggestedLatency =
-      (!functions.Pa_GetDeviceInfo(outputDevice)).defaultLowOutputLatency,
+    suggestedLatency = (!functions.Pa_GetDeviceInfo(outputDevice)).defaultLowOutputLatency,
     hostApiSpecificStreamInfo = null
   )
 

--- a/src/main/scala/pedals/chunk.scala
+++ b/src/main/scala/pedals/chunk.scala
@@ -4,8 +4,7 @@ import cats.Semigroup
 import cats.effect.Concurrent
 import fs2.{Chunk, Stream}
 
-given streamPointwiseAddChunks[F[_]: Concurrent]
-    : Semigroup[Stream[F, Chunk[Float]]] = new:
+given streamPointwiseAddChunks[F[_]: Concurrent]: Semigroup[Stream[F, Chunk[Float]]] = new:
   def combine(
       x: Stream[F, Chunk[Float]],
       y: Stream[F, Chunk[Float]]

--- a/src/main/scala/pedals/tremolo/waveforms/util/waveSection.scala
+++ b/src/main/scala/pedals/tremolo/waveforms/util/waveSection.scala
@@ -10,11 +10,9 @@ def waveSection(
   val buffer = new Array[Float](FRAMES_PER_BUFFER)
 
   def go(chunkNumber: Long): Pull[Pure, Float, Option[Long]] =
-    for (i <- 0 until FRAMES_PER_BUFFER) do
-      buffer(i) = f((chunkNumber * FRAMES_PER_BUFFER) + i)
+    for (i <- 0 until FRAMES_PER_BUFFER) do buffer(i) = f((chunkNumber * FRAMES_PER_BUFFER) + i)
     Pull.output(Chunk.array(buffer)) >> (
-      if chunkNumber < sectionLengthInChunks then
-        Pull.pure(Some(chunkNumber + 1))
+      if chunkNumber < sectionLengthInChunks then Pull.pure(Some(chunkNumber + 1))
       else Pull.pure(None)
     )
   Pull.loop[Pure, Float, Long](go)(0).stream


### PR DESCRIPTION
I know GitHub mobile only shows 80 characters of a line at a time but the default `maxColumn = 80` makes it basically impossible to have both descriptive variable names and a comprehensible layout in this project.