### PR TITLE
Simplify reverb so we don't have to normalise the chunk size

### DIFF
--- a/src/main/scala/arpeggio/Main.scala
+++ b/src/main/scala/arpeggio/Main.scala
@@ -8,7 +8,7 @@ object Main extends IOApp.Simple:
     .resource[IO]
     .use(audioSuite =>
       audioSuite.input
-        .through(pedals.reverb.schroeder(30, 100))
+        .through(pedals.reverb.schroeder(predelayMillis = 30, decayMillis = 100))
         .through(audioSuite.output)
         .compile
         .drain

--- a/src/main/scala/arpeggio/constants/constants.scala
+++ b/src/main/scala/arpeggio/constants/constants.scala
@@ -1,7 +1,7 @@
 package arpeggio
 package constants
 
-val SAMPLE_RATE = 192000f
+val SAMPLE_RATE = 11025f
 val FRAMES_PER_BUFFER = 256
 
 val CHUNKS_PER_SECOND: Float = SAMPLE_RATE / FRAMES_PER_BUFFER

--- a/src/main/scala/arpeggio/pedals/delay/package.scala
+++ b/src/main/scala/arpeggio/pedals/delay/package.scala
@@ -1,7 +1,7 @@
 package arpeggio
 package pedals.delay
 
-import arpeggio.constants.{CHUNKS_PER_SECOND, FRAMES_PER_BUFFER}
+import arpeggio.constants.SAMPLE_RATE
 import arpeggio.routing.Fork
 import cats.effect.Concurrent
 import fs2.{Chunk, Stream}
@@ -9,41 +9,39 @@ import cats.syntax.semigroup.*
 import arpeggio.routing.parallel
 import arpeggio.pubsub.ChunkedChannel.*
 
-def silence[F[_]](timeInMs: Float): Stream[F, Float] =
-  val delayTimeInChunks = (timeInMs * CHUNKS_PER_SECOND / 1000).toInt
-  val silenceChunkArray = Array.fill(FRAMES_PER_BUFFER)(0f)
-  val silenceChunk = Chunk.array(silenceChunkArray)
-  Stream.chunk(silenceChunk).repeatN(delayTimeInChunks)
+def silence[F[_]](timeInMillis: Float): Stream[F, Float] =
+  val timeInFrames = (timeInMillis * SAMPLE_RATE / 1000).toInt
+  Stream.chunk(Chunk.constant(0, timeInFrames))
 
-def delayLine[F[_]: Concurrent](timeInMs: Float): Pedal[F] = stream =>
+def delayLine[F[_]: Concurrent](timeInMillis: Float): Pedal[F] = stream =>
   Stream
     .eval(ChunkedChannel.unbounded[F, Float])
     .flatMap(channel =>
       channel.stream.concurrently(
-        (silence(timeInMs) ++ stream)
+        (silence(timeInMillis) ++ stream)
           .through(channel.sendAll)
       )
     )
 
 def echo[F[_]: Concurrent](
     repeatGain: Float,
-    delayTimeInSeconds: Float
+    delayTimeMillis: Float
 ): Pedal[F] =
   parallel(
     identity,
-    echoRepeats(repeatGain, delayTimeInSeconds).andThen(_.map(_ * repeatGain))
+    echoRepeats(repeatGain, delayTimeMillis).andThen(_.map(_ * repeatGain))
   )
 
 def echoRepeats[F[_]: Concurrent](
     repeatGain: Float,
-    delayTimeInSeconds: Float
+    delayTimeMillis: Float
 ): Pedal[F] = stream =>
   Stream
     .resource(Fork[F])
     .flatMap(fork =>
       fork.lOut
         .concurrently(
-          fork.in(stream |+| fork.rOut.through(delayLine(delayTimeInSeconds)).map(_ * repeatGain))
+          fork.in(stream |+| fork.rOut.through(delayLine(delayTimeMillis)).map(_ * repeatGain))
         )
-        .through(delayLine(delayTimeInSeconds))
+        .through(delayLine(delayTimeMillis))
     )

--- a/src/main/scala/arpeggio/pedals/reverb/schroeder.scala
+++ b/src/main/scala/arpeggio/pedals/reverb/schroeder.scala
@@ -6,28 +6,28 @@ import arpeggio.routing.parallel
 import cats.effect.Concurrent
 
 def schroeder[F[_]: Concurrent](
-    predelayTimeInMs: Float, // = 30
-    reverbTimeInMs: Float
+    predelayMillis: Float,
+    decayMillis: Float
 ): Pedal[F] =
-  val t1 = predelayTimeInMs
-  val t2 = predelayTimeInMs * 1.17f
-  val t3 = predelayTimeInMs * 1.34f
-  val t4 = predelayTimeInMs * 1.5f
+  val t1 = predelayMillis
+  val t2 = predelayMillis * 1.17f
+  val t3 = predelayMillis * 1.34f
+  val t4 = predelayMillis * 1.5f
   parallel(
     identity,
     parallel(
-      echoRepeats(gain(reverbTimeInMs, t1), t1),
-      echoRepeats(gain(reverbTimeInMs, t2), t2),
-      echoRepeats(gain(reverbTimeInMs, t3), t3),
-      echoRepeats(gain(reverbTimeInMs, t4), t4)
+      echoRepeats(gain(decayMillis, t1), t1),
+      echoRepeats(gain(decayMillis, t2), t2),
+      echoRepeats(gain(decayMillis, t3), t3),
+      echoRepeats(gain(decayMillis, t4), t4)
     ).andThen(
       allPassStage(0.7, 5)
         .andThen(allPassStage(0.7, 1.7))
     )
   )
 
-def gain(reverbTimeInMs: Float, predelayTimeInMs: Float): Float =
-  scala.math.pow(2, (-3f * predelayTimeInMs) / reverbTimeInMs).toFloat
+def gain(decayMillis: Float, predelayMillis: Float): Float =
+  scala.math.pow(2, (-3f * predelayMillis) / decayMillis).toFloat
 
 def allPassStage[F[_]: Concurrent](
     repeatGain: Float,


### PR DESCRIPTION
This is more correct with regards to delay times. It also does not require a very large sample rate in order to be accurate. It is however, much less performant and so the sample rate is lowered to make sure the app can keep up.