### PR TITLE
Re-chunk echoRepeats outputs in Schroeder implementation

### DIFF
--- a/core/src/main/scala/arpeggio/package.scala
+++ b/core/src/main/scala/arpeggio/package.scala
@@ -12,3 +12,7 @@ given pointwiseAdd[F[_]]: Semigroup[Stream[F, Float]] =
         y: Stream[F, Float]
     ): Stream[F, Float] =
       x.zipWith(y)(_ + _)
+
+extension [F[_], A](stream: Stream[F, A])
+  def rechunkN(n: Int): Stream[F, A] =
+    stream.chunkN(n).unchunks


### PR DESCRIPTION
Since the outputs of the different echo stages are zipped together with `pointwiseAdd`, the differing chunk size can lead to the end chunk sizes being extremely small (and often 1). Re-chunking each echo ouput improves CPU usage by a LOT.